### PR TITLE
セッションに値を保存する

### DIFF
--- a/sample25/index.php
+++ b/sample25/index.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+$_SESSION['session_message'] = '値をセッションに保存しました！';  //PHPでセッションを使う場合は「$_SESSION」という特殊な変数に値を代入
+?>
+<!DOCTYPE html>
+<html>
+<head>
+ <title>sample</title>
+ <meta http-equiv="content-type" charset="utf-8">
+</head>
+<pre>
+  セッションに値を保存しました。次のページに移動してみましょう！
+  &raquo; <a href="page02.php">Page02へ</a>
+</pre>
+</html>

--- a/sample25/page02.php
+++ b/sample25/page02.php
@@ -1,0 +1,12 @@
+<?php session_start(); //初期化処理を行う必要あり?>
+<!DOCTYPE html>
+<html>
+<head>
+ <title>sample</title>
+ <meta http-equiv="content-type" charset="utf-8">
+</head>
+<pre>
+  セッションの値：　<?php print($_SESSION['session_message']); //セッション変数を画面に表示させています?>
+  <?php session_unset(); //セッションの内容を全て削除します?>
+</pre>
+</html>


### PR DESCRIPTION
#What
session_start()ファンクション
unsetファンクション
セッションID（無作為な英数字の羅列）
セッションハイジャック(セッションIDが盗聴されたりすると、セッションを乗っ取って不正に値を取り出させる)

#Why
PHP学習のため

ログインが必要なWebサイトなどで、ログイン後に画面を移動した場合にログイン中であることを覚えて
おかなければなりません。前節のCookieを利用しても実現はできますが、このような「Webブラウザを開いている間だけ」
覚えさせておきたいものは、セッションという仕組みを利用すると便利です。